### PR TITLE
Timestamps and clean-up

### DIFF
--- a/Documentation.mdown
+++ b/Documentation.mdown
@@ -1,48 +1,32 @@
-### Overview
+## Overview ##
 
-This plugin gives Quicksilver the ability to edit text files by appending text
-lines to the end of a file, prepending text or changing or deleting lines
-within a file. The plugin allows manipulation of .txt, .rtf, .rtfd, .doc and
-.TEXT files.
+This plugin gives Quicksilver the ability to edit text files by appending text lines to the end of a file, prepending text or changing or deleting lines within a file. The plugin allows manipulation of `.txt`, `.rtf`, `.rtfd`, `.doc` and `.TEXT` files.
 
-Note that Quicksilver has the ability to enter into text files (using → or /)
-and list the contents of the file, which can be used in conjunction with this
-plugin for increased flexibility.
+Note that Quicksilver has the ability to enter into text files (using → or /) and list the contents of the file, which can be used in conjunction with this plugin for increased flexibility.
 
-### Actions
+### Actions ###
 
-#### Append Text... and Append To...
-
-Append some text to the selected text file. You can append text to a text
+Append Text… and Append To…
+  : Append some text to the selected text file. You can append text to a text
 file, or to a line within a text file (if you have entered a text file with →
 or /). This action is reversible. You can:
 
-  * [Some File] ⇥ Append Text... ⇥ [Some Text]
-  * [Some Text] ⇥ Append To... ⇥ [Some File]
+      * [Some File] ⇥ Append Text… ⇥ [Some Text]
+      * [Some Text] ⇥ Append To… ⇥ [Some File]
 
-You should note that both these actions can use Quicksilver's 'smart' ability
-to place any item, object or file inside a text file. If you append an image
-to a text file, the path of the image is added, or similarly for web addresses
-(URLs). When entering a text file (→ or /), these lines are automatically
-resolved by Quicksilver into the original file, URL etc.
+    You should note that these actions can use Quicksilver's “smart” ability to place any item, object or file inside a text file. If you append an image to a text file, the path of the image is added, or similarly for web addresses (URLs). When entering a text file (→ or /), these lines are automatically resolved by Quicksilver into the original file, URL etc.
 
-This gives you a convenient way to store any file or piece of information
-within a text file, using nothing but Quicksilver.
+    This gives you a convenient way to store and retrieve any file or piece of information within a text file, using nothing but Quicksilver.
 
-#### Prepend Text... and Prepend To...
+Prepend Text… and Prepend To…
+  : This action works in a similar manner to the 'Append' actions, but puts a line of text at the start of the file. The action is also reversible.
 
-This action works in a similar manner to the 'Append' actions, but puts a line
-of text at the start of the file. The action is also reversible.
+Change To…
+  : The Change to… action is available for lines within a text file. To view lines, press → or / to enter into a text file. It allows for the modification of a specific line within a file.
 
-#### Change To...
+Delete Line
+  : As with the Change To… action, the Delete Line action is available for lines within a text file. It can be used to remove certain lines from within a given file.
 
-The Change to... action is available for lines within a text file. To view
-lines, press → or / to enter into a text file. It allows for the modification
-of a specific line within a file.
+#### Timestamps ####
 
-#### Delete Line
-
-As with the Change To... action, the Delete Line action is available for lines
-within a text file. It can be used to remove certain lines from within a given
-file.
-
+All of the Append/Prepend actions have alternates that will include a timestamp at the beginning of the line. The timestamp's format is taken from the “Short” format for Date and Time in System Preferences, so you can customize it there.

--- a/Documentation.mdown
+++ b/Documentation.mdown
@@ -1,0 +1,48 @@
+### Overview
+
+This plugin gives Quicksilver the ability to edit text files by appending text
+lines to the end of a file, prepending text or changing or deleting lines
+within a file. The plugin allows manipulation of .txt, .rtf, .rtfd, .doc and
+.TEXT files.
+
+Note that Quicksilver has the ability to enter into text files (using → or /)
+and list the contents of the file, which can be used in conjunction with this
+plugin for increased flexibility.
+
+### Actions
+
+#### Append Text... and Append To...
+
+Append some text to the selected text file. You can append text to a text
+file, or to a line within a text file (if you have entered a text file with →
+or /). This action is reversible. You can:
+
+  * [Some File] ⇥ Append Text... ⇥ [Some Text]
+  * [Some Text] ⇥ Append To... ⇥ [Some File]
+
+You should note that both these actions can use Quicksilver's 'smart' ability
+to place any item, object or file inside a text file. If you append an image
+to a text file, the path of the image is added, or similarly for web addresses
+(URLs). When entering a text file (→ or /), these lines are automatically
+resolved by Quicksilver into the original file, URL etc.
+
+This gives you a convenient way to store any file or piece of information
+within a text file, using nothing but Quicksilver.
+
+#### Prepend Text... and Prepend To...
+
+This action works in a similar manner to the 'Append' actions, but puts a line
+of text at the start of the file. The action is also reversible.
+
+#### Change To...
+
+The Change to... action is available for lines within a text file. To view
+lines, press → or / to enter into a text file. It allows for the modification
+of a specific line within a file.
+
+#### Delete Line
+
+As with the Change To... action, the Delete Line action is available for lines
+within a text file. It can be used to remove certain lines from within a given
+file.
+

--- a/Info.plist
+++ b/Info.plist
@@ -280,41 +280,38 @@
 		<key>description</key>
 		<string>Actions for manipulating text lines in files</string>
 		<key>extendedDescription</key>
-		<string>&lt;h3&gt;Overview&lt;/h3&gt;
-&lt;p&gt;This plugin gives Quicksilver the ability to edit text files by appending text
-lines to the end of a file, prepending text or changing or deleting lines
-within a file. The plugin allows manipulation of .txt, .rtf, .rtfd, .doc and
-.TEXT files.&lt;/p&gt;
-&lt;p&gt;Note that Quicksilver has the ability to enter into text files (using → or /)
-and list the contents of the file, which can be used in conjunction with this
-plugin for increased flexibility.&lt;/p&gt;
+		<string>&lt;h2&gt;Overview&lt;/h2&gt;
+&lt;p&gt;This plugin gives Quicksilver the ability to edit text files by appending text lines to the end of a file, prepending text or changing or deleting lines within a file. The plugin allows manipulation of &lt;code&gt;.txt&lt;/code&gt;, &lt;code&gt;.rtf&lt;/code&gt;, &lt;code&gt;.rtfd&lt;/code&gt;, &lt;code&gt;.doc&lt;/code&gt; and &lt;code&gt;.TEXT&lt;/code&gt; files.&lt;/p&gt;
+&lt;p&gt;Note that Quicksilver has the ability to enter into text files (using → or /) and list the contents of the file, which can be used in conjunction with this plugin for increased flexibility.&lt;/p&gt;
 &lt;h3&gt;Actions&lt;/h3&gt;
-&lt;h4&gt;Append Text... and Append To...&lt;/h4&gt;
+&lt;dl&gt;
+&lt;dt&gt;Append Text… and Append To…&lt;/dt&gt;
+&lt;dd&gt;
 &lt;p&gt;Append some text to the selected text file. You can append text to a text
 file, or to a line within a text file (if you have entered a text file with →
 or /). This action is reversible. You can:&lt;/p&gt;
 &lt;ul&gt;
-&lt;li&gt;[Some File] ⇥ Append Text... ⇥ [Some Text]&lt;/li&gt;
-&lt;li&gt;[Some Text] ⇥ Append To... ⇥ [Some File]&lt;/li&gt;
+&lt;li&gt;[Some File] ⇥ Append Text… ⇥ [Some Text]&lt;/li&gt;
+&lt;li&gt;[Some Text] ⇥ Append To… ⇥ [Some File]&lt;/li&gt;
 &lt;/ul&gt;
-&lt;p&gt;You should note that both these actions can use Quicksilver's 'smart' ability
-to place any item, object or file inside a text file. If you append an image
-to a text file, the path of the image is added, or similarly for web addresses
-(URLs). When entering a text file (→ or /), these lines are automatically
-resolved by Quicksilver into the original file, URL etc.&lt;/p&gt;
-&lt;p&gt;This gives you a convenient way to store any file or piece of information
-within a text file, using nothing but Quicksilver.&lt;/p&gt;
-&lt;h4&gt;Prepend Text... and Prepend To...&lt;/h4&gt;
-&lt;p&gt;This action works in a similar manner to the 'Append' actions, but puts a line
-of text at the start of the file. The action is also reversible.&lt;/p&gt;
-&lt;h4&gt;Change To...&lt;/h4&gt;
-&lt;p&gt;The Change to... action is available for lines within a text file. To view
-lines, press → or / to enter into a text file. It allows for the modification
-of a specific line within a file.&lt;/p&gt;
-&lt;h4&gt;Delete Line&lt;/h4&gt;
-&lt;p&gt;As with the Change To... action, the Delete Line action is available for lines
-within a text file. It can be used to remove certain lines from within a given
-file.&lt;/p&gt;</string>
+&lt;p&gt;You should note that these actions can use Quicksilver's “smart” ability to place any item, object or file inside a text file. If you append an image to a text file, the path of the image is added, or similarly for web addresses (URLs). When entering a text file (→ or /), these lines are automatically resolved by Quicksilver into the original file, URL etc.&lt;/p&gt;
+&lt;p&gt;This gives you a convenient way to store and retrieve any file or piece of information within a text file, using nothing but Quicksilver.&lt;/p&gt;
+&lt;/dd&gt;
+&lt;dt&gt;Prepend Text… and Prepend To…&lt;/dt&gt;
+&lt;dd&gt;
+&lt;p&gt;This action works in a similar manner to the 'Append' actions, but puts a line of text at the start of the file. The action is also reversible.&lt;/p&gt;
+&lt;/dd&gt;
+&lt;dt&gt;Change To…&lt;/dt&gt;
+&lt;dd&gt;
+&lt;p&gt;The Change to… action is available for lines within a text file. To view lines, press → or / to enter into a text file. It allows for the modification of a specific line within a file.&lt;/p&gt;
+&lt;/dd&gt;
+&lt;dt&gt;Delete Line&lt;/dt&gt;
+&lt;dd&gt;
+&lt;p&gt;As with the Change To… action, the Delete Line action is available for lines within a text file. It can be used to remove certain lines from within a given file.&lt;/p&gt;
+&lt;/dd&gt;
+&lt;/dl&gt;
+&lt;h4&gt;Timestamps&lt;/h4&gt;
+&lt;p&gt;All of the Append/Prepend actions have alternates that will include a timestamp at the beginning of the line. The timestamp's format is taken from the “Short” format for Date and Time in System Preferences, so you can customize it there.&lt;/p&gt;</string>
 		<key>icon</key>
 		<string>ClippingText</string>
 		<key>relatedBundles </key>

--- a/Info.plist
+++ b/Info.plist
@@ -76,24 +76,6 @@
 			<key>precedence</key>
 			<string>0.01</string>
 		</dict>
-		<key>QSTextAppendTimedAction</key>
-		<dict>
-			<key>actionClass</key>
-			<string>QSTextManipulationPlugIn</string>
-			<key>actionSelector</key>
-			<string>appendTimestampedObject:toObject:</string>
-			<key>directTypes</key>
-			<array>
-				<string>NSStringPboardType</string>
-				<string>NSFilenamesPboardType</string>
-			</array>
-			<key>indirectTypes</key>
-			<array>
-				<string>public.text</string>
-			</array>
-			<key>name</key>
-			<string>Append with Timestamp To…</string>
-		</dict>
 		<key>QSTextAppendReverseAction</key>
 		<dict>
 			<key>actionClass</key>
@@ -128,6 +110,24 @@
 			<key>validatesObjects</key>
 			<string>YES</string>
 		</dict>
+		<key>QSTextAppendTimedAction</key>
+		<dict>
+			<key>actionClass</key>
+			<string>QSTextManipulationPlugIn</string>
+			<key>actionSelector</key>
+			<string>appendTimestampedObject:toObject:</string>
+			<key>directTypes</key>
+			<array>
+				<string>NSStringPboardType</string>
+				<string>NSFilenamesPboardType</string>
+			</array>
+			<key>indirectTypes</key>
+			<array>
+				<string>public.text</string>
+			</array>
+			<key>name</key>
+			<string>Append with Timestamp To…</string>
+		</dict>
 		<key>QSTextAppendTimedReverseAction</key>
 		<dict>
 			<key>actionClass</key>
@@ -141,7 +141,7 @@
 				<string>rtf</string>
 				<string>rtfd</string>
 				<string>doc</string>
-				<string>&apos;TEXT&apos;</string>
+				<string>'TEXT'</string>
 				<string>md</string>
 				<string>markdown</string>
 				<string>mdown</string>
@@ -182,26 +182,6 @@
 			<key>precedence</key>
 			<string>0.01</string>
 		</dict>
-		<key>QSTextPrependTimedAction</key>
-		<dict>
-			<key>actionClass</key>
-			<string>QSTextManipulationPlugIn</string>
-			<key>actionSelector</key>
-			<string>prependTimestampedObject:toObject:</string>
-			<key>directTypes</key>
-			<array>
-				<string>NSStringPboardType</string>
-				<string>NSFilenamesPboardType</string>
-			</array>
-			<key>enabled</key>
-			<false/>
-			<key>indirectTypes</key>
-			<array>
-				<string>public.text</string>
-			</array>
-			<key>name</key>
-			<string>Prepend with Timestamp To…</string>
-		</dict>
 		<key>QSTextPrependReverseAction</key>
 		<dict>
 			<key>actionClass</key>
@@ -236,6 +216,26 @@
 			<key>validatesObjects</key>
 			<string>YES</string>
 		</dict>
+		<key>QSTextPrependTimedAction</key>
+		<dict>
+			<key>actionClass</key>
+			<string>QSTextManipulationPlugIn</string>
+			<key>actionSelector</key>
+			<string>prependTimestampedObject:toObject:</string>
+			<key>directTypes</key>
+			<array>
+				<string>NSStringPboardType</string>
+				<string>NSFilenamesPboardType</string>
+			</array>
+			<key>enabled</key>
+			<false/>
+			<key>indirectTypes</key>
+			<array>
+				<string>public.text</string>
+			</array>
+			<key>name</key>
+			<string>Prepend with Timestamp To…</string>
+		</dict>
 		<key>QSTextPrependTimedReverseAction</key>
 		<dict>
 			<key>actionClass</key>
@@ -248,7 +248,7 @@
 				<string>rtf</string>
 				<string>doc</string>
 				<string>rtfd</string>
-				<string>&apos;TEXT&apos;</string>
+				<string>'TEXT'</string>
 				<string>md</string>
 				<string>markdown</string>
 				<string>mdown</string>
@@ -281,29 +281,40 @@
 		<string>Actions for manipulating text lines in files</string>
 		<key>extendedDescription</key>
 		<string>&lt;h3&gt;Overview&lt;/h3&gt;
-&lt;p&gt;This plugin gives Quicksilver the ability to edit text files by appending text lines to the end of a file, prepending text or changing or deleting lines within a file. The plugin allows manipulation of .txt, .rtf, .rtfd, .doc and .TEXT files.&lt;br /&gt;
-Note that Quicksilver has the ability to enter into text files (using → or /) and list the contents of the file, which can be used in conjunction with this plugin for increased flexibility.&lt;/p&gt;
-
+&lt;p&gt;This plugin gives Quicksilver the ability to edit text files by appending text
+lines to the end of a file, prepending text or changing or deleting lines
+within a file. The plugin allows manipulation of .txt, .rtf, .rtfd, .doc and
+.TEXT files.&lt;/p&gt;
+&lt;p&gt;Note that Quicksilver has the ability to enter into text files (using → or /)
+and list the contents of the file, which can be used in conjunction with this
+plugin for increased flexibility.&lt;/p&gt;
 &lt;h3&gt;Actions&lt;/h3&gt;
-
 &lt;h4&gt;Append Text... and Append To...&lt;/h4&gt;
-&lt;p&gt;Append some text to the selected text file. You can append text to a text file, or to a line within a text file (if you have entered a text file with → or /). This action is reversible. You can:&lt;/p&gt;
+&lt;p&gt;Append some text to the selected text file. You can append text to a text
+file, or to a line within a text file (if you have entered a text file with →
+or /). This action is reversible. You can:&lt;/p&gt;
 &lt;ul&gt;
 &lt;li&gt;[Some File] ⇥ Append Text... ⇥ [Some Text]&lt;/li&gt;
 &lt;li&gt;[Some Text] ⇥ Append To... ⇥ [Some File]&lt;/li&gt;
 &lt;/ul&gt;
-
-&lt;p&gt;You should note that both these actions can use Quicksilver's 'smart' ability to place any item, object or file inside a text file. If you append an image to a text file, the path of the image is added, or similarly for web addresses (URLs). When entering a text file (→ or /), these lines are automatically resolved by Quicksilver into the original file, URL etc.&lt;br /&gt;
-This gives you a convenient way to store any file or piece of information within a text file, using nothing but Quicksilver.&lt;/p&gt;
-
+&lt;p&gt;You should note that both these actions can use Quicksilver's 'smart' ability
+to place any item, object or file inside a text file. If you append an image
+to a text file, the path of the image is added, or similarly for web addresses
+(URLs). When entering a text file (→ or /), these lines are automatically
+resolved by Quicksilver into the original file, URL etc.&lt;/p&gt;
+&lt;p&gt;This gives you a convenient way to store any file or piece of information
+within a text file, using nothing but Quicksilver.&lt;/p&gt;
 &lt;h4&gt;Prepend Text... and Prepend To...&lt;/h4&gt;
-&lt;p&gt;This action works in a similar manner to the 'Append' actions, but puts a line of text at the start of the file. The action is also reversible.&lt;/p&gt;
-
+&lt;p&gt;This action works in a similar manner to the 'Append' actions, but puts a line
+of text at the start of the file. The action is also reversible.&lt;/p&gt;
 &lt;h4&gt;Change To...&lt;/h4&gt;
-&lt;p&gt;The Change to... action is available for lines within a text file. To view lines, press → or / to enter into a text file. It allows for the modification of a specific line within a file.&lt;/p&gt;
-
+&lt;p&gt;The Change to... action is available for lines within a text file. To view
+lines, press → or / to enter into a text file. It allows for the modification
+of a specific line within a file.&lt;/p&gt;
 &lt;h4&gt;Delete Line&lt;/h4&gt;
-&lt;p&gt;As with the Change To... action, the Delete Line action is available for lines within a text file. It can be used to remove certain lines from within a given file.&lt;/p&gt;</string>
+&lt;p&gt;As with the Change To... action, the Delete Line action is available for lines
+within a text file. It can be used to remove certain lines from within a given
+file.&lt;/p&gt;</string>
 		<key>icon</key>
 		<string>ClippingText</string>
 		<key>relatedBundles </key>
@@ -334,7 +345,7 @@ This gives you a convenient way to store any file or piece of information within
 	<key>QSRequirements</key>
 	<dict>
 		<key>version</key>
-		<string>3940</string>
+		<string>4001</string>
 	</dict>
 </dict>
 </plist>

--- a/Info.plist
+++ b/Info.plist
@@ -52,7 +52,7 @@
 			<key>enabled</key>
 			<false/>
 			<key>name</key>
-			<string>Change To...</string>
+			<string>Change To…</string>
 			<key>validatesObjects</key>
 			<string>YES</string>
 		</dict>
@@ -72,7 +72,7 @@
 				<string>public.text</string>
 			</array>
 			<key>name</key>
-			<string>Append To...</string>
+			<string>Append To…</string>
 			<key>precedence</key>
 			<string>0.01</string>
 		</dict>
@@ -102,7 +102,7 @@
 				<string>QSLineReferenceType</string>
 			</array>
 			<key>name</key>
-			<string>Append Text...</string>
+			<string>Append Text…</string>
 			<key>precedence</key>
 			<string>0.02</string>
 			<key>reverseArguments</key>
@@ -178,7 +178,7 @@
 				<string>public.text</string>
 			</array>
 			<key>name</key>
-			<string>Prepend To...</string>
+			<string>Prepend To…</string>
 			<key>precedence</key>
 			<string>0.01</string>
 		</dict>
@@ -208,7 +208,7 @@
 			<key>enabled</key>
 			<false/>
 			<key>name</key>
-			<string>Prepend Text...</string>
+			<string>Prepend Text…</string>
 			<key>precedence</key>
 			<string>0.02</string>
 			<key>reverseArguments</key>

--- a/Info.plist
+++ b/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.1</string>
+	<string>1.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>80</string>
+	<string>81</string>
 	<key>QSActions</key>
 	<dict>
 		<key>QSLineRefDeleteAction</key>

--- a/Info.plist
+++ b/Info.plist
@@ -62,6 +62,8 @@
 			<string>QSTextManipulationPlugIn</string>
 			<key>actionSelector</key>
 			<string>appendObject:toObject:</string>
+			<key>alternateAction</key>
+			<string>QSTextAppendTimedAction</string>
 			<key>directTypes</key>
 			<array>
 				<string>NSStringPboardType</string>
@@ -82,6 +84,8 @@
 			<string>QSTextManipulationPlugIn</string>
 			<key>actionSelector</key>
 			<string>appendObject:toObject:</string>
+			<key>alternateAction</key>
+			<string>QSTextAppendTimedReverseAction</string>
 			<key>directFileTypes</key>
 			<array>
 				<string>txt</string>
@@ -166,6 +170,8 @@
 			<string>QSTextManipulationPlugIn</string>
 			<key>actionSelector</key>
 			<string>prependObject:toObject:</string>
+			<key>alternateAction</key>
+			<string>QSTextPrependTimedAction</string>
 			<key>directTypes</key>
 			<array>
 				<string>NSStringPboardType</string>
@@ -188,6 +194,8 @@
 			<string>QSTextManipulationPlugIn</string>
 			<key>actionSelector</key>
 			<string>prependObject:toObject:</string>
+			<key>alternateAction</key>
+			<string>QSTextPrependTimedReverseAction</string>
 			<key>directFileTypes</key>
 			<array>
 				<string>txt</string>

--- a/Info.plist
+++ b/Info.plist
@@ -76,6 +76,24 @@
 			<key>precedence</key>
 			<string>0.01</string>
 		</dict>
+		<key>QSTextAppendTimedAction</key>
+		<dict>
+			<key>actionClass</key>
+			<string>QSTextManipulationPlugIn</string>
+			<key>actionSelector</key>
+			<string>appendTimestampedObject:toObject:</string>
+			<key>directTypes</key>
+			<array>
+				<string>NSStringPboardType</string>
+				<string>NSFilenamesPboardType</string>
+			</array>
+			<key>indirectTypes</key>
+			<array>
+				<string>public.text</string>
+			</array>
+			<key>name</key>
+			<string>Append with Timestamp To…</string>
+		</dict>
 		<key>QSTextAppendReverseAction</key>
 		<dict>
 			<key>actionClass</key>
@@ -110,6 +128,38 @@
 			<key>validatesObjects</key>
 			<string>YES</string>
 		</dict>
+		<key>QSTextAppendTimedReverseAction</key>
+		<dict>
+			<key>actionClass</key>
+			<string>QSTextManipulationPlugIn</string>
+			<key>actionSelector</key>
+			<string>appendTimestampedObject:toObject:</string>
+			<key>directFileTypes</key>
+			<array>
+				<string>txt</string>
+				<string>csv</string>
+				<string>rtf</string>
+				<string>rtfd</string>
+				<string>doc</string>
+				<string>&apos;TEXT&apos;</string>
+				<string>md</string>
+				<string>markdown</string>
+				<string>mdown</string>
+				<string>mkdn</string>
+				<string>public.text</string>
+			</array>
+			<key>directTypes</key>
+			<array>
+				<string>NSFilenamesPboardType</string>
+				<string>QSLineReferenceType</string>
+			</array>
+			<key>name</key>
+			<string>Append Text with Timestamp…</string>
+			<key>reverseArguments</key>
+			<true/>
+			<key>validatesObjects</key>
+			<string>YES</string>
+		</dict>
 		<key>QSTextPrependAction</key>
 		<dict>
 			<key>actionClass</key>
@@ -131,6 +181,26 @@
 			<string>Prepend To...</string>
 			<key>precedence</key>
 			<string>0.01</string>
+		</dict>
+		<key>QSTextPrependTimedAction</key>
+		<dict>
+			<key>actionClass</key>
+			<string>QSTextManipulationPlugIn</string>
+			<key>actionSelector</key>
+			<string>prependTimestampedObject:toObject:</string>
+			<key>directTypes</key>
+			<array>
+				<string>NSStringPboardType</string>
+				<string>NSFilenamesPboardType</string>
+			</array>
+			<key>enabled</key>
+			<false/>
+			<key>indirectTypes</key>
+			<array>
+				<string>public.text</string>
+			</array>
+			<key>name</key>
+			<string>Prepend with Timestamp To…</string>
 		</dict>
 		<key>QSTextPrependReverseAction</key>
 		<dict>
@@ -161,6 +231,38 @@
 			<string>Prepend Text...</string>
 			<key>precedence</key>
 			<string>0.02</string>
+			<key>reverseArguments</key>
+			<true/>
+			<key>validatesObjects</key>
+			<string>YES</string>
+		</dict>
+		<key>QSTextPrependTimedReverseAction</key>
+		<dict>
+			<key>actionClass</key>
+			<string>QSTextManipulationPlugIn</string>
+			<key>actionSelector</key>
+			<string>prependTimestampedObject:toObject:</string>
+			<key>directFileTypes</key>
+			<array>
+				<string>txt</string>
+				<string>rtf</string>
+				<string>doc</string>
+				<string>rtfd</string>
+				<string>&apos;TEXT&apos;</string>
+				<string>md</string>
+				<string>markdown</string>
+				<string>mdown</string>
+				<string>mkdn</string>
+			</array>
+			<key>directTypes</key>
+			<array>
+				<string>NSFilenamesPboardType</string>
+				<string>QSLineReferenceType</string>
+			</array>
+			<key>enabled</key>
+			<false/>
+			<key>name</key>
+			<string>Prepend Text with Timestamp…</string>
 			<key>reverseArguments</key>
 			<true/>
 			<key>validatesObjects</key>

--- a/Info.plist
+++ b/Info.plist
@@ -64,6 +64,8 @@
 			<string>appendObject:toObject:</string>
 			<key>alternateAction</key>
 			<string>QSTextAppendTimedAction</string>
+			<key>commandFormat</key>
+			<string>Append “%@” to %@</string>
 			<key>directTypes</key>
 			<array>
 				<string>NSStringPboardType</string>
@@ -86,6 +88,8 @@
 			<string>appendObject:toObject:</string>
 			<key>alternateAction</key>
 			<string>QSTextAppendTimedReverseAction</string>
+			<key>commandFormat</key>
+			<string>Append line to %@ containing “%@”</string>
 			<key>directFileTypes</key>
 			<array>
 				<string>txt</string>
@@ -120,6 +124,8 @@
 			<string>QSTextManipulationPlugIn</string>
 			<key>actionSelector</key>
 			<string>appendTimestampedObject:toObject:</string>
+			<key>commandFormat</key>
+			<string>Append “%@” with timestamp to %@</string>
 			<key>directTypes</key>
 			<array>
 				<string>NSStringPboardType</string>
@@ -138,6 +144,8 @@
 			<string>QSTextManipulationPlugIn</string>
 			<key>actionSelector</key>
 			<string>appendTimestampedObject:toObject:</string>
+			<key>commandFormat</key>
+			<string>Append timestamped line to %@ containing “%@”</string>
 			<key>directFileTypes</key>
 			<array>
 				<string>txt</string>
@@ -172,6 +180,8 @@
 			<string>prependObject:toObject:</string>
 			<key>alternateAction</key>
 			<string>QSTextPrependTimedAction</string>
+			<key>commandFormat</key>
+			<string>Prepend “%@” to %@</string>
 			<key>directTypes</key>
 			<array>
 				<string>NSStringPboardType</string>
@@ -196,6 +206,8 @@
 			<string>prependObject:toObject:</string>
 			<key>alternateAction</key>
 			<string>QSTextPrependTimedReverseAction</string>
+			<key>commandFormat</key>
+			<string>Prepend line to %@ containing “%@”</string>
 			<key>directFileTypes</key>
 			<array>
 				<string>txt</string>
@@ -230,6 +242,8 @@
 			<string>QSTextManipulationPlugIn</string>
 			<key>actionSelector</key>
 			<string>prependTimestampedObject:toObject:</string>
+			<key>commandFormat</key>
+			<string>Prepend “%@” with timestamp to %@</string>
 			<key>directTypes</key>
 			<array>
 				<string>NSStringPboardType</string>
@@ -250,6 +264,8 @@
 			<string>QSTextManipulationPlugIn</string>
 			<key>actionSelector</key>
 			<string>prependTimestampedObject:toObject:</string>
+			<key>commandFormat</key>
+			<string>Prepend timestamped line to %@ containing “%@”</string>
 			<key>directFileTypes</key>
 			<array>
 				<string>txt</string>

--- a/QSTextManipulationPlugIn.h
+++ b/QSTextManipulationPlugIn.h
@@ -9,8 +9,12 @@
 #import "QSTextManipulationPlugIn.h"
 
 @interface QSTextManipulationPlugIn : NSObject
+
+@property (retain) NSDateFormatter *dateFormatter;
+@property (retain) NSArray *reverseActions;
+
 - (QSObject *) prependObject:(QSObject *)dObject toObject:(QSObject *)iObject;
 - (QSObject *) appendObject:(QSObject *)dObject toObject:(QSObject *)iObject;
-- (QSObject *) appendObject:(QSObject *)dObject toObject:(QSObject *)iObject atBeginning:(BOOL)atBeginning;
+- (QSObject *) appendObject:(QSObject *)dObject toObject:(QSObject *)iObject withTimestamp:(BOOL)includeTime atBeginning:(BOOL)atBeginning;
 @end
 

--- a/QSTextManipulationPlugIn.m
+++ b/QSTextManipulationPlugIn.m
@@ -113,7 +113,7 @@
             NSStringEncoding encoding;
 
             NSString *string = [NSString stringWithContentsOfFile:file usedEncoding:&encoding error:nil];
-            NSMutableArray *lines = [[[string lines] mutableCopy] autorelease]; 		
+            NSMutableArray *lines = [[string lines] mutableCopy];
             NSUInteger lineIndex = [[reference objectForKey:@"line"] unsignedIntegerValue];
             if (atBeginning) {
                 lineIndex--;
@@ -126,7 +126,7 @@
             NSString *type = [[NSFileManager defaultManager] typeOfFile:path];
             
             // rich text
-        if (UTTypeConformsTo((CFStringRef)[iObject fileUTI], (CFStringRef)@"public.rtf") || [richTextTypes containsObject:type]) {
+        if (UTTypeConformsTo((__bridge CFStringRef)[iObject fileUTI], (__bridge CFStringRef)@"public.rtf") || [richTextTypes containsObject:type]) {
                 NSDictionary *docAttributes = nil;
                 NSError *error = nil;
                 NSMutableAttributedString *astring = [[NSMutableAttributedString alloc] initWithURL:[NSURL fileURLWithPath:path]
@@ -135,8 +135,8 @@
                                                                                               error:&error];
                 NSDictionary *attributes = [astring attributesAtIndex:atBeginning ? 0 : [astring length]-1
                                                        effectiveRange:nil];
-                NSAttributedString *newlineString = [[[NSAttributedString alloc] initWithString:@"\n" attributes:attributes] autorelease];
-                NSAttributedString *appendString = [[[NSAttributedString alloc] initWithString:newLine  attributes:attributes] autorelease];
+                NSAttributedString *newlineString = [[NSAttributedString alloc] initWithString:@"\n" attributes:attributes];
+                NSAttributedString *appendString = [[NSAttributedString alloc] initWithString:newLine  attributes:attributes];
                 
                 if (atBeginning) {
                     [astring insertAttributedString:newlineString atIndex:0];
@@ -155,7 +155,7 @@
                 if (!error)
                     [wrapper writeToFile:path atomically:NO updateFilenames:YES];
                 
-        } else if (UTTypeConformsTo((CFStringRef)[iObject fileUTI], (CFStringRef)@"public.text") || [textTypes containsObject:type]) {
+        } else if (UTTypeConformsTo((__bridge CFStringRef)[iObject fileUTI], (__bridge CFStringRef)@"public.text") || [textTypes containsObject:type]) {
                 NSStringEncoding encoding;
                 NSString *text = [NSString stringWithContentsOfFile:path usedEncoding:&encoding error:nil];
                 if (atBeginning || ![text length]) {
@@ -191,7 +191,7 @@
     
     string = [string stringByReplacing:@"\n" with:@"\r"];
     
-    NSMutableArray *lines = [[[string componentsSeparatedByString:@"\r"] mutableCopy] autorelease];
+    NSMutableArray *lines = [[string componentsSeparatedByString:@"\r"] mutableCopy];
     
     NSString *fileLine = [lines objectAtIndex:lineNum];
     
@@ -214,7 +214,7 @@
     
     NSStringEncoding encoding;
     NSString *string = [NSString stringWithContentsOfFile:file usedEncoding:&encoding error:nil];
-    NSMutableArray *lines = [[[string lines] mutableCopy] autorelease];
+    NSMutableArray *lines = [[string lines] mutableCopy];
     
     
     NSString *fileLine = [lines objectAtIndex:lineNum];

--- a/QSTextManipulationPlugIn.m
+++ b/QSTextManipulationPlugIn.m
@@ -17,8 +17,8 @@
 #define kQSTextPrependTimedAction @"QSTextPrependTimedAction"
 #define kQSTextAppendTimedReverseAction @"QSTextAppendTimedReverseAction"
 #define kQSTextPrependTimedReverseAction @"QSTextPrependTimedReverseAction"
-#define textTypes [NSArray arrayWithObjects:@"'TEXT'", @"txt", @"sh", @"pl", @"rb", @"html", @"htm",@"md",@"markdown", @"mdown", @"mkdn", nil]
-#define richTextTypes [NSArray arrayWithObjects:@"rtf", @"doc", @"rtfd", nil]
+#define textTypes @[@"'TEXT'", @"txt", @"sh", @"pl", @"rb", @"html", @"htm",@"md",@"markdown", @"mdown", @"mkdn"]
+#define richTextTypes @[@"rtf", @"doc", @"rtfd"]
 
 @implementation QSTextManipulationPlugIn
 

--- a/TextManipulationElement.xcodeproj/project.pbxproj
+++ b/TextManipulationElement.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4D0C0DC20E0FCED80027D189 /* Debug.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 			};
 			name = Debug;
 		};
@@ -206,6 +207,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4D0C0DC60E0FCED80027D189 /* Release.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 			};
 			name = Release;
 		};

--- a/TextManipulationElement.xcodeproj/project.pbxproj
+++ b/TextManipulationElement.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 44;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -123,8 +123,11 @@
 /* Begin PBXProject section */
 		0259C573FE90428111CA0C5A /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0500;
+			};
 			buildConfigurationList = 7FFF2583085E488700266176 /* Build configuration list for PBXProject "TextManipulationElement" */;
-			compatibilityVersion = "Xcode 3.0";
+			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
@@ -182,7 +185,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 14A8CFE310CE4C3D003857E3 /* QSPlugIn.xcconfig */;
 			buildSettings = {
-				PRODUCT_NAME = "Text Manipulation";
 			};
 			name = Debug;
 		};
@@ -190,7 +192,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 14A8CFE310CE4C3D003857E3 /* QSPlugIn.xcconfig */;
 			buildSettings = {
-				PRODUCT_NAME = "Text Manipulation";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
You can include a timestamp now with all the append/prepend actions. I made the timestamped versions alternates to the traditional ones.

Could come in handy if you want to use Event Triggers to log events, or create a trigger for

    “I farted” ⇥ Append with Timestamp To… ⇥ ~/Documents/fart.log

…or whatever.

See the commits for the various other clean-up stuff.